### PR TITLE
fix(ios): restore iOS ad fill parity with Android (0.1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.8
+
+* Fix iOS external user IDs (EIDs) never reaching the bid request: the values were stored under the `uniqueIds` key but the native SDK reads `uids`, so `user.ext.eids` went out with no IDs on iOS (Android was unaffected). EIDs now serialize correctly, restoring iOS demand/fill for publishers using external identity
+* Fix iOS banner ads not setting a `rootViewController` on the GMA banner before load, which could cause failed loads and unrecorded impressions/clicks
+* Fix iOS `isLazyLoad` defaulting to `true` when the argument was absent (now `false`, matching the Dart default) — an accidental lazy load never fetches inside a Flutter platform view on iOS
+* Fix invalid schain JSON generated during remote initialization: `asi`/`sid` string values were interpolated unquoted, producing malformed JSON
+
 ## 0.1.7
 
 * Add `pauseAllAutoRefresh()` / `resumeAllAutoRefresh()` to pause and resume auto-refresh across all loaded banner ads (e.g. when showing a full-screen overlay the SDK can't see)

--- a/android/src/main/kotlin/com/audienzz/audienzz_sdk_flutter/AudienzzSdkWrapper.kt
+++ b/android/src/main/kotlin/com/audienzz/audienzz_sdk_flutter/AudienzzSdkWrapper.kt
@@ -7,7 +7,7 @@ import org.audienzz.mobile.AudienzzTargetingParams
 import com.audienzz.audienzz_sdk_flutter.entities.InitializationStatus
 import io.flutter.plugin.common.MethodChannel.Result
 
-private const val FLUTTER_SDK_VERSION = "0.1.7"
+private const val FLUTTER_SDK_VERSION = "0.1.8"
 
 class AudienzzSdkWrapper {
     fun initialize(context: Context, companyId: String, isAutomaticPpidEnabled: Boolean, prebidServerUrl: String?, result: Result){

--- a/ios/Classes/Ads/Implementation/FBannerAd.swift
+++ b/ios/Classes/Ads/Implementation/FBannerAd.swift
@@ -144,6 +144,11 @@ class FBannerAd: FBaseAd, FAd, FlutterPlatformView, BannerViewDelegate {
         bannerViewInstance = AdManagerBannerView(adSize: adSizeFor(cgSize: CGSize(width: mainSize.width, height: mainSize.height)))
         bannerViewInstance!.adUnitID = adUnitId
         bannerViewInstance!.delegate = self
+        // GMA requires a rootViewController on the banner before load(); without it the
+        // load can fail and impressions/clicks aren't recorded. This was set on the
+        // SDK's own reference banner but missing here — an iOS-only gap (Android needs
+        // only a Context, which it has).
+        bannerViewInstance!.rootViewController = rootViewController
 
         var validAdSizes: [NSValue] = [nsValue(for: adSizeFor(cgSize: CGSize(width: mainSize.width, height: mainSize.height)))]
 

--- a/ios/Classes/AudienzzSdkFlutterPlugin.swift
+++ b/ios/Classes/AudienzzSdkFlutterPlugin.swift
@@ -3,7 +3,7 @@ import Flutter
 import PrebidMobile
 import UIKit
 
-private let flutterSdkVersion = "0.1.7"
+private let flutterSdkVersion = "0.1.8"
 
 public class AudienzzSdkFlutterPlugin: NSObject, FlutterPlugin {
     private var manager: AdInstanceManager
@@ -115,7 +115,11 @@ public class AudienzzSdkFlutterPlugin: NSObject, FlutterPlugin {
             let pbAdSlot = args["pbAdSlot"] as? String
             let gpId = args["gpId"] as? String
             let customImpOrtbConfig = args["impOrtbConfig"] as? String
-            let isLazyLoad = args["isLazyLoad"] as? Bool ?? true
+            // Default to false to match the Dart BannerAd default; on iOS a lazy-load
+            // banner inside a Flutter platform view never fetches (VisibleView relies on
+            // a UIScrollView ancestor that doesn't exist here), so an accidental default
+            // of true would silently produce no fill.
+            let isLazyLoad = args["isLazyLoad"] as? Bool ?? false
             let smartRefresh = args["smartRefresh"] as? Bool ?? false
             let prefetchMarginPoints = CGFloat((args["prefetchMargin"] as? Int) ?? 200)
 

--- a/ios/Classes/TargetingWrapper/AudienzzTargetingWrapper.swift
+++ b/ios/Classes/TargetingWrapper/AudienzzTargetingWrapper.swift
@@ -84,7 +84,19 @@ class AudienzzTargetingWrapper {
         }
 
         if let externalUserIds = args["externalUserIds"] as? [[String: Any]] {
-            AUTargeting.shared.eids = externalUserIds
+            // Dart sends each EID as { source, uniqueIds: [{id, atype, ext}] }, but the
+            // native SDK's `ExternalUserId.from(json:)` reads the `uids` key
+            // (OpenRTB user.ext.eids[].uids). Without this rename the uids array parses
+            // empty, so every EID carries a source but no actual ID — useless to bidders.
+            // That is why iOS ad requests carried no usable external IDs while Android did.
+            let normalized = externalUserIds.map { eid -> [String: Any] in
+                var out = eid
+                if let uniqueIds = out.removeValue(forKey: "uniqueIds") {
+                    out["uids"] = uniqueIds
+                }
+                return out
+            }
+            AUTargeting.shared.eids = normalized
         } else {
             AUTargeting.shared.eids = nil
         }

--- a/ios/audienzz_sdk_flutter.podspec
+++ b/ios/audienzz_sdk_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'audienzz_sdk_flutter'
-  s.version          = '0.1.7'
+  s.version          = '0.1.8'
   s.summary          = 'Flutter wrapper for Audienzz Mobile SDK'
   s.description      = <<-DESC
 Flutter wrapper for Audienzz Mobile SDK

--- a/lib/src/audienzz_sdk_flutter.dart
+++ b/lib/src/audienzz_sdk_flutter.dart
@@ -68,8 +68,8 @@ final class AudienzzSdkFlutter {
                                 "complete": 1,
                                 "nodes": [
                                     {
-                                        "asi": $advertisingSystemDomain,
-                                        "sid": $sellerId,
+                                        "asi": "$advertisingSystemDomain",
+                                        "sid": "$sellerId",
                                         "hp": 1
                                     }
                                   ]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audienzz_sdk_flutter
 description: "A Flutter plugin that integrates Audienzz Mobile Advertising SDK for easy implementation of advanced ad solutions"
-version: 0.1.7
+version: 0.1.8
 homepage: https://audienzz.com/
 repository: https://github.com/audienzz/audienzz-flutter-sdk
 issue_tracker: https://github.com/audienzz/audienzz-flutter-sdk/issues


### PR DESCRIPTION
Deep iOS-vs-Android investigation of the "iOS almost never fills" report surfaced iOS-only defects in the plugin/Dart layer (no native SDK release needed):

- EIDs: iOS stored external user IDs under `uniqueIds`, but the native SDK reads `uids`, so user.ext.eids went out with a source but no IDs on iOS (Android correct). Rename on set so EIDs actually reach the bid request.
- Banner: set `rootViewController` on the GMA AdManagerBannerView before load(); it was dropped on iOS, risking failed loads / unrecorded impressions.
- isLazyLoad: default to false (was true) when the arg is absent — an accidental lazy load never fetches inside a Flutter platform view on iOS.
- schain: quote `asi`/`sid` string values in the remote-init JSON (were interpolated unquoted, producing invalid JSON).

Verified: iOS simulator build, Android debug APK, dart analyze.